### PR TITLE
Allow open source licenses to be included in addons

### DIFF
--- a/include/AddonWhiteList.h
+++ b/include/AddonWhiteList.h
@@ -95,6 +95,9 @@ namespace Addon
 			"data_static/*.xml",
 			"data_static/*.csv",
 
+            // Open source license files
+            "license/*.txt",
+
 			NULL
 		};
 


### PR DESCRIPTION
I'm writing an addon that uses AGPL code and therefore I need to get a copy of the AGPL to whoever decides to unpack my addon in the future.

I went with a folder rather than a single file because various licenses demand different names, `NOTICE.txt` files etc, so rather than trying to whitelist all of them and make things a bit messy, a folder full of arbitrary files allows people to do whatever, including put different licenses for different bits of the codebase (eg if they've used CC BY assets)